### PR TITLE
Add support for other kinds of drawers

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ In your `build.gradle`:
 ```groovy
 dependencies {
   implementation 'com.drakeet.drawer:drawer:0.9.0'
+  // Optional: No need if you just use the FullDraggableHelper
+  implementation 'androidx.drawerlayout:drawerlayout:1.1.1'
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Replace the main Layout of `DrawerLayout` with the `FullDraggableContainer` (or 
 ## TODO
 
 - [x] Add support for the right drawer / RTL
-- [ ] Add support for other kinds of drawer
+- [x] Add support for other kinds of drawer
 
 License
 -------

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ In your `build.gradle`:
 
 ```groovy
 dependencies {
-  implementation 'com.drakeet.drawer:drawer:0.9.0'
+  implementation 'com.drakeet.drawer:drawer:1.0.0'
   // Optional: No need if you just use the FullDraggableHelper
   implementation 'androidx.drawerlayout:drawerlayout:1.1.1'
 }
@@ -51,6 +51,10 @@ Replace the main Layout of `DrawerLayout` with the `FullDraggableContainer` (or 
 ```
 
 **That's all, you're good to go!**
+
+### Advanced usage
+
+See `com.drakeet.drawer.FullDraggableHelper`
 
 ## TODO
 

--- a/build.gradle
+++ b/build.gradle
@@ -17,8 +17,8 @@
 buildscript {
 
   ext.kotlinVersion = '1.4.21'
-  ext.buildConfig = ['versionCode'      : 2,
-                     'versionName'      : "0.9.1",
+  ext.buildConfig = ['versionCode'      : 3,
+                     'versionName'      : "1.0.0",
                      'compileSdkVersion': 30,
                      'minSdkVersion'    : 19,
                      'targetSdkVersion' : 30]

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -34,6 +34,6 @@ android {
 }
 
 dependencies {
-  api 'androidx.drawerlayout:drawerlayout:1.1.1'
+  compileOnly 'androidx.drawerlayout:drawerlayout:1.1.1'
   testImplementation 'junit:junit:4.13.1'
 }

--- a/library/gradle.properties
+++ b/library/gradle.properties
@@ -20,7 +20,7 @@ POM_PACKAGING=aar
 
 GROUP=com.drakeet.drawer
 
-POM_DESCRIPTION=Easier and more flexible to create multiple types for Android RecyclerView.
+POM_DESCRIPTION=Make Android DrawerLayout can be dragged out in real-time within the range of fullscreen.
 POM_URL=https://github.com/PureWriter/FullDraggableDrawer
 POM_SCM_URL=https://github.com/PureWriter/FullDraggableDrawer
 POM_SCM_CONNECTION=scm:git@github.com:PureWriter/FullDraggableDrawer.git

--- a/library/src/main/java/com/drakeet/drawer/FullDraggableHelper.java
+++ b/library/src/main/java/com/drakeet/drawer/FullDraggableHelper.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) 2021. Drakeet Xu
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.drakeet.drawer;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.view.Gravity;
+import android.view.MotionEvent;
+import android.view.VelocityTracker;
+import android.view.View;
+import android.view.ViewConfiguration;
+import android.view.ViewGroup;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import static java.lang.Math.abs;
+
+/**
+ * @author Drakeet Xu
+ */
+public class FullDraggableHelper {
+
+  @NonNull
+  private final Context context;
+  @NonNull
+  private final Callback callback;
+
+  private float initialMotionX;
+  private float initialMotionY;
+  private float lastMotionX;
+  private final int touchSlop;
+  private final int swipeSlop;
+  private final int distanceThreshold;
+  private final int xVelocityThreshold;
+
+  private boolean isDraggingDrawer = false;
+  private boolean shouldOpenDrawer = false;
+
+  @Nullable
+  private VelocityTracker velocityTracker = null;
+  private int gravity = Gravity.NO_GRAVITY;
+
+  public FullDraggableHelper(@NonNull Context context, @NonNull Callback callback) {
+    this.context = context;
+    this.callback = callback;
+    touchSlop = ViewConfiguration.get(context).getScaledTouchSlop();
+    swipeSlop = dipsToPixels(8);
+    distanceThreshold = dipsToPixels(80);
+    xVelocityThreshold = dipsToPixels(150);
+  }
+
+  public boolean onInterceptTouchEvent(MotionEvent event) {
+    boolean intercepted = false;
+    int action = event.getActionMasked();
+    float x = event.getX();
+    float y = event.getY();
+    if (action == MotionEvent.ACTION_DOWN) {
+      lastMotionX = initialMotionX = x;
+      initialMotionY = y;
+      return false;
+    } else if (action == MotionEvent.ACTION_MOVE) {
+      if (canNestedViewScroll(callback.getDrawerMainContainer(), false, (int) (x - lastMotionX), (int) x, (int) y)) {
+        return false;
+      }
+      lastMotionX = x;
+      float diffX = x - initialMotionX;
+      intercepted = abs(diffX) > touchSlop
+        && abs(diffX) > abs(y - initialMotionY)
+        && isDrawerEnabled(diffX);
+    }
+    return intercepted;
+  }
+
+  @SuppressLint({ "RtlHardcoded" })
+  public boolean onTouchEvent(MotionEvent event) {
+    float x = event.getX();
+    int action = event.getActionMasked();
+    switch (action) {
+      case MotionEvent.ACTION_MOVE: {
+        float diffX = x - initialMotionX;
+        if (isDrawerOpen() || !isDrawerEnabled(diffX)) {
+          return false;
+        }
+        float absDiffX = abs(diffX);
+        if (absDiffX > swipeSlop || isDraggingDrawer) {
+          if (velocityTracker == null) {
+            velocityTracker = VelocityTracker.obtain();
+          }
+          velocityTracker.addMovement(event);
+          boolean lastDraggingDrawer = isDraggingDrawer;
+          isDraggingDrawer = true;
+          shouldOpenDrawer = absDiffX > distanceThreshold;
+
+          // Not allowed to change direction in a process
+          if (gravity == Gravity.NO_GRAVITY) {
+            gravity = diffX > 0 ? Gravity.LEFT : Gravity.RIGHT;
+          }
+          callback.offsetDrawer(gravity, absDiffX - swipeSlop);
+
+          if (!lastDraggingDrawer) {
+            callback.onDrawerDragging();
+          }
+        }
+        return isDraggingDrawer;
+      }
+      case MotionEvent.ACTION_CANCEL:
+      case MotionEvent.ACTION_UP: {
+        if (isDraggingDrawer) {
+          if (velocityTracker != null) {
+            velocityTracker.computeCurrentVelocity(1000);
+            float xVelocity = velocityTracker.getXVelocity();
+            boolean fromLeft = (gravity == Gravity.LEFT);
+            if (xVelocity > xVelocityThreshold) {
+              shouldOpenDrawer = fromLeft;
+            } else if (xVelocity < -xVelocityThreshold) {
+              shouldOpenDrawer = !fromLeft;
+            }
+          }
+          if (shouldOpenDrawer) {
+            callback.smoothOpenDrawer(gravity);
+          } else {
+            callback.smoothCloseDrawer(gravity);
+          }
+        }
+        shouldOpenDrawer = false;
+        isDraggingDrawer = false;
+        gravity = Gravity.NO_GRAVITY;
+        if (velocityTracker != null) {
+          velocityTracker.recycle();
+          velocityTracker = null;
+        }
+      }
+    }
+    return true;
+  }
+
+  private boolean canNestedViewScroll(View view, boolean checkSelf, int dx, int x, int y) {
+    if (view instanceof ViewGroup) {
+      ViewGroup group = (ViewGroup) view;
+      int scrollX = view.getScrollX();
+      int scrollY = view.getScrollY();
+      int count = group.getChildCount();
+      for (int i = count - 1; i >= 0; i--) {
+        View child = group.getChildAt(i);
+        if (child.getVisibility() != View.VISIBLE) continue;
+        if (x + scrollX >= child.getLeft()
+          && x + scrollX < child.getRight()
+          && y + scrollY >= child.getTop()
+          && y + scrollY < child.getBottom()
+          && canNestedViewScroll(child, true, dx, x + scrollX - child.getLeft(), y + scrollY - child.getTop())) {
+          return true;
+        }
+      }
+    }
+    return checkSelf && view.canScrollHorizontally(-dx);
+  }
+
+  @SuppressLint("RtlHardcoded")
+  private boolean isDrawerOpen() {
+    return callback.isDrawerOpen(Gravity.LEFT) || callback.isDrawerOpen(Gravity.RIGHT);
+  }
+
+  @SuppressLint("RtlHardcoded")
+  private boolean isDrawerEnabled(float direction) {
+    return direction > 0 && callback.hasEnabledDrawer(Gravity.LEFT)
+      || direction < 0 && callback.hasEnabledDrawer(Gravity.RIGHT);
+  }
+
+  private int dipsToPixels(int dips) {
+    float scale = context.getResources().getDisplayMetrics().density;
+    return (int) (dips * scale + 0.5f);
+  }
+
+  public interface Callback {
+    @NonNull
+    View getDrawerMainContainer();
+    boolean isDrawerOpen(int gravity);
+    boolean hasEnabledDrawer(int gravity);
+    void offsetDrawer(int gravity, float offset);
+    void smoothOpenDrawer(int gravity);
+    void smoothCloseDrawer(int gravity);
+    void onDrawerDragging();
+  }
+}

--- a/library/src/main/java/com/drakeet/drawer/FullDraggableHelper.java
+++ b/library/src/main/java/com/drakeet/drawer/FullDraggableHelper.java
@@ -46,12 +46,12 @@ public class FullDraggableHelper {
   private final int distanceThreshold;
   private final int xVelocityThreshold;
 
+  private int gravity = Gravity.NO_GRAVITY;
   private boolean isDraggingDrawer = false;
   private boolean shouldOpenDrawer = false;
 
   @Nullable
   private VelocityTracker velocityTracker = null;
-  private int gravity = Gravity.NO_GRAVITY;
 
   public FullDraggableHelper(@NonNull Context context, @NonNull Callback callback) {
     this.context = context;

--- a/sample/src/main/java/com/drakeet/drawer/sample/MainActivity.kt
+++ b/sample/src/main/java/com/drakeet/drawer/sample/MainActivity.kt
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.drakeet.drawer.sample
 
 import android.content.Context


### PR DESCRIPTION
Add a `FullDraggableHelper` to hold the reusable part so that we can use it for other kinds of drawers.

* Rename `dismissDrawer()` to `smoothCloseDrawer()`
* Make _drawerlayout_ as an optional and `compileOnly` dependency